### PR TITLE
Fix optim interactions

### DIFF
--- a/src/modules/Map/services/mapUtils.js
+++ b/src/modules/Map/services/mapUtils.js
@@ -1,15 +1,14 @@
 import bbox from '@turf/bbox';
 
-import moize from 'moize';
 import { PREFIXES } from './cluster';
 
 const PREV_STATE = {};
 
-export const getLayers = moize((map, layerId) => {
+export const getLayers = (map, layerId) => {
   const regexp = new RegExp(`^${layerId}(-(${PREFIXES.join('|')}))?(-[0-9]+)?$`);
   return map.getStyle().layers
     .filter(({ id }) => id.match(regexp));
-});
+};
 
 export function toggleLayerVisibility (map, layerId, visibility) {
   getLayers(map, layerId)
@@ -83,25 +82,66 @@ export const checkContraints = ({
   }, false);
 };
 
-let listenerWaiter = 0;
+export function getInteractionsOnEvent ({
+  eventType,
+  map,
+  point,
+  interactions: eventInteractions,
+}) {
+  let features;
+  try {
+    features = map.queryRenderedFeatures(point);
+  } catch (e) {
+    return null;
+  }
 
+  let interactions = false;
+
+  features.some(feature => {
+    const { layer: { id: layerId } } = feature;
+
+    const foundInteractions = eventInteractions.filter(({ id, trigger = 'click', constraints }) => {
+      const found = getLayers(map, id).find(({ id: compatibleId }) =>
+        layerId === compatibleId &&
+        map.getLayoutProperty(compatibleId, 'visibility') === 'visible');
+
+      if (!found || (constraints && !checkContraints({ map, constraints, feature }))) {
+        return false;
+      }
+
+      return found &&
+        eventType === (trigger === 'mouseover' ? 'mousemove' : trigger);
+    });
+
+    if (!foundInteractions.length) return false;
+
+    interactions = {
+      interactions: foundInteractions,
+      feature,
+      layerId,
+    };
+
+    return true;
+  });
+
+  return interactions;
+}
+
+const listenerWaiter = {};
 export function setInteractions ({ map, interactions, callback }) {
   const eventsTypes = new Set(interactions.reduce((triggers, { trigger = 'click' }) => [...triggers, trigger], []));
 
-  // 'mouseover' is the trigger, 'mousemove' is the eventType
   if (eventsTypes.has('mouseover')) {
     eventsTypes.add('mousemove');
     eventsTypes.delete('mouseover');
   }
 
   let hoveringClickableLayer = 0;
-  const uniqueHoveringEvents = {};
   const canvas = map.getCanvas();
   interactions.forEach(interaction => {
     // Display a pointer cursor over click zones for the given layer
     const { id, trigger = 'click' } = interaction;
-    if (['click', 'mouseover'].includes(trigger) && !uniqueHoveringEvents[id]) {
-      uniqueHoveringEvents[id] = true;
+    if (['click', 'mouseover'].includes(trigger)) {
       map.on('mouseenter', id, () => {
         hoveringClickableLayer += 1;
         if (hoveringClickableLayer === 1) {
@@ -122,53 +162,34 @@ export function setInteractions ({ map, interactions, callback }) {
 
     const eventType = 'mouseleave';
     map.on(eventType, id, event => {
-      callback({
-        event,
-        map,
-        layerId: id,
-        interaction,
-        feature: PREV_STATE.point,
-        eventType,
-      });
+      const features = map.queryRenderedFeatures(PREV_STATE.point);
+      const feature = features.find(({ layer: { id: layerId } }) => id === layerId);
+      callback({ event, map, layerId: id, interaction, feature, eventType });
     });
   });
 
-  interactions.forEach(interaction => {
-    const { id, trigger = 'click', constraints } = interaction;
-    map.on(trigger === 'mouseover' ? 'mousemove' : trigger, id, e => {
-      const { features } = e;
+  const listener = (e, eventType) => {
+    const { target, point } = e;
+    if (eventType === 'mousemove') {
+      PREV_STATE.point = point;
+    }
+    const interactionsSpec = getInteractionsOnEvent({
+      eventType,
+      map: target,
+      point,
+      interactions,
+    });
 
-      if (!features.some(feature => !constraints || checkContraints({
-        map,
-        constraints,
-        feature,
-      }))) {
-        return;
-      }
+    if (!interactionsSpec) return;
 
-      if (trigger === 'mouseover') {
-        clearTimeout(listenerWaiter);
-        listenerWaiter = setTimeout(() => {
-          PREV_STATE.point = e.point;
-          return callback({
-            event: e,
-            map,
-            layerId: id,
-            feature: features && features[0],
-            interaction,
-            eventType: 'mousemove',
-          });
-        }, 100);
-      } else {
-        callback({
-          event: e,
-          map,
-          layerId: id,
-          feature: features && features[0],
-          interaction,
-          eventType: trigger,
-        });
-      }
+    const { interactions: filteredInteractionsSpec, feature, layerId } = interactionsSpec;
+    filteredInteractionsSpec.forEach(interaction =>
+      callback({ event: e, map, layerId, feature, interaction, eventType }));
+  };
+  eventsTypes.forEach(eventType => {
+    map.on(eventType, e => {
+      clearTimeout(listenerWaiter[eventType]);
+      listenerWaiter[eventType] = setTimeout(() => listener(e, eventType), eventType === 'mousemove' ? 200 : 100);
     });
   });
 }
@@ -182,6 +203,7 @@ export default {
   toggleLayerVisibility,
   getOpacityProperty,
   setLayerOpacity,
+  getInteractionsOnEvent,
   setInteractions,
   checkContraints,
   fitZoom,

--- a/src/modules/Map/services/mapUtils.js
+++ b/src/modules/Map/services/mapUtils.js
@@ -1,14 +1,17 @@
 import bbox from '@turf/bbox';
+import moize from 'moize';
 
 import { PREFIXES } from './cluster';
 
 const PREV_STATE = {};
 
-export const getLayers = (map, layerId) => {
+export const getLayers = moize({
+  serializer: (map, layerId) => `${layerId}${map.getStyle().layers.map(id => id).join('')}`,
+})((map, layerId) => {
   const regexp = new RegExp(`^${layerId}(-(${PREFIXES.join('|')}))?(-[0-9]+)?$`);
   return map.getStyle().layers
     .filter(({ id }) => id.match(regexp));
-};
+});
 
 export function toggleLayerVisibility (map, layerId, visibility) {
   getLayers(map, layerId)

--- a/src/modules/Map/services/mapUtils.js
+++ b/src/modules/Map/services/mapUtils.js
@@ -103,7 +103,15 @@ export function getInteractionsOnEvent ({
       const found = getRelatedLayers(map, id)
         .find(({ id: compatibleId }) => layerId === compatibleId);
 
-      return found && (!constraints || checkContraints({ map, constraints, feature }));
+      if (!found) {
+        return false;
+      }
+
+      if (!constraints) {
+        return true;
+      }
+
+      return checkContraints({ map, constraints, feature });
     });
 
     if (!foundInteractions.length) return false;

--- a/src/modules/Map/services/mapUtils.js
+++ b/src/modules/Map/services/mapUtils.js
@@ -136,28 +136,12 @@ export function setInteractions ({ map, interactions, callback }) {
     eventsTypes.delete('mouseover');
   }
 
-  let hoveringClickableLayer = 0;
-  const canvas = map.getCanvas();
+  /**
+   * Mouseleave events for mouseover triggers
+   * /!\ this listener MUST be before the mousemove
+   */
   interactions.forEach(interaction => {
-    // Display a pointer cursor over click zones for the given layer
-    const { id, trigger = 'click' } = interaction;
-    if (['click', 'mouseover'].includes(trigger)) {
-      map.on('mouseenter', id, () => {
-        hoveringClickableLayer += 1;
-        if (hoveringClickableLayer === 1) {
-          canvas.style.cursor = 'pointer';
-        }
-      });
-      map.on('mouseleave', id, () => {
-        hoveringClickableLayer -= 1;
-        if (hoveringClickableLayer === 0) {
-          canvas.style.cursor = '';
-        }
-      });
-    }
-
-    // Mouseleave events for mouseover triggers
-    // /!\ this listener MUST be before the mousemove
+    const { id, trigger } = interaction;
     if (trigger !== 'mouseover') return;
 
     const eventType = 'mouseleave';
@@ -191,6 +175,26 @@ export function setInteractions ({ map, interactions, callback }) {
       clearTimeout(listenerWaiter[eventType]);
       listenerWaiter[eventType] = setTimeout(() => listener(e, eventType), eventType === 'mousemove' ? 200 : 100);
     });
+  });
+
+  /**
+   *  Display a pointer cursor over click zones
+   */
+  map.on('mousemove', e => {
+    const { target, point } = e;
+    const interactionsSpec = getInteractionsOnEvent({
+      eventType: 'click',
+      map: target,
+      point,
+      interactions,
+    });
+
+    const canvas = target.getCanvas();
+    if (interactionsSpec) {
+      canvas.style.cursor = 'pointer';
+    } else {
+      canvas.style.cursor = '';
+    }
   });
 }
 

--- a/src/modules/Map/services/mapUtils.test.js
+++ b/src/modules/Map/services/mapUtils.test.js
@@ -1,5 +1,5 @@
 import {
-  getLayers,
+  getRelatedLayers,
   toggleLayerVisibility,
   getOpacityProperty,
   setLayerOpacity,
@@ -51,18 +51,18 @@ it('should get all layers related to main one', () => {
     getStyle,
   };
 
-  expect(getLayers(map, 'foo')).toEqual([{
+  expect(getRelatedLayers(map, 'foo')).toEqual([{
     id: 'foo',
     type: 'fill',
     paint: {
       'fill-opacity': 1,
     },
   }]);
-  expect(getLayers(map, 'bar')).toEqual([{
+  expect(getRelatedLayers(map, 'bar')).toEqual([{
     id: 'bar',
   }]);
 
-  expect(getLayers(map, 'layer')).toEqual([{
+  expect(getRelatedLayers(map, 'layer')).toEqual([{
     id: 'layer-0',
     type: 'fill',
     paint: {

--- a/src/modules/Map/services/mapUtils.test.js
+++ b/src/modules/Map/services/mapUtils.test.js
@@ -3,6 +3,7 @@ import {
   toggleLayerVisibility,
   getOpacityProperty,
   setLayerOpacity,
+  getInteractionsOnEvent,
   setInteractions,
   checkContraints,
   fitZoom,
@@ -118,6 +119,122 @@ it('should set layer opacity', () => {
   expect(map.setPaintProperty).not.toHaveBeenCalled();
 });
 
+it('should get interaction on event', () => {
+  const interactions = [{
+    id: 'foo',
+  }, {
+    id: 'bar',
+    trigger: 'mouseover',
+  }, {
+    id: 'foobar',
+    trigger: 'click',
+  }];
+  const map = {
+    getStyle,
+    getLayoutProperty: jest.fn(() => 'visible'),
+    queryRenderedFeatures: jest.fn(() => [{
+      layer: {
+        id: 'foo',
+      },
+    }, {
+      layer: {
+        id: 'bar',
+      },
+    }, {
+      layer: {
+        id: 'foobar',
+      },
+    }]),
+  };
+  const eventType = 'click';
+  const point = [1, 2];
+  const interaction = getInteractionsOnEvent({ eventType, map, point, interactions });
+
+  expect(map.queryRenderedFeatures).toHaveBeenCalledWith(point);
+  expect(interaction).toEqual({
+    interactions: [interactions[0]],
+    feature: {
+      layer: {
+        id: 'foo',
+      },
+    },
+    layerId: 'foo',
+  });
+});
+
+it('should get interaction on mouseover event', () => {
+  const interactions = [{
+    id: 'foo',
+    trigger: 'click',
+  }, {
+    id: 'bar',
+    trigger: 'mouseover',
+  }, {
+    id: 'foobar',
+  }];
+  const map = {
+    getStyle,
+    getLayoutProperty: jest.fn(() => 'visible'),
+    queryRenderedFeatures: jest.fn(() => [{
+      layer: {
+        id: 'foo',
+      },
+    }, {
+      layer: {
+        id: 'bar',
+      },
+    }, {
+      layer: {
+        id: 'foobar',
+      },
+    }]),
+  };
+  const eventType = 'mousemove';
+  const point = [1, 2];
+  const interaction = getInteractionsOnEvent({ eventType, map, point, interactions });
+
+  expect(map.queryRenderedFeatures).toHaveBeenCalledWith(point);
+  expect(interaction).toEqual({
+    interactions: [interactions[1]],
+    feature: {
+      layer: {
+        id: 'bar',
+      },
+    },
+    layerId: 'bar',
+  });
+});
+
+it('should get no interaction on event', () => {
+  const interactions = [{
+    id: 'foo',
+    trigger: 'click',
+  }, {
+    id: 'bar',
+    trigger: 'click',
+  }];
+  const map = {
+    getStyle,
+    getLayoutProperty: jest.fn(() => 'visible'),
+    queryRenderedFeatures: jest.fn(() => [{
+      layer: {
+        id: 'foo',
+      },
+    }, {
+      layer: {
+        id: 'bar',
+      },
+    }]),
+  };
+  const eventType = 'mousover';
+  const point = [1, 2];
+  const interaction = getInteractionsOnEvent({ eventType, map, point, interactions });
+
+  expect(map.queryRenderedFeatures).toHaveBeenCalledWith(point);
+  expect(interaction).toBe(false);
+});
+
+
 describe('should set interactions', () => {
   let listeners = [];
   const canvas = { style: {} };
@@ -130,14 +247,6 @@ describe('should set interactions', () => {
       id: listener ? id : null,
     })),
     getCanvas: jest.fn(() => canvas),
-  };
-  const event = {
-    point: [1, 2],
-    features: [{
-      layer: {
-        id: 'foo',
-      },
-    }],
   };
   beforeEach(() => {
     listeners = [];
@@ -183,6 +292,20 @@ describe('should set interactions', () => {
       interaction: 'doSomething',
     }];
     const callback = jest.fn();
+    const event = { target: map, point: [1, 2] };
+    map.queryRenderedFeatures = () => [{
+      layer: {
+        id: 'foo',
+      },
+    }, {
+      layer: {
+        id: 'bar',
+      },
+    }, {
+      layer: {
+        id: 'foobar',
+      },
+    }];
 
     setInteractions({ map, interactions, callback });
     listeners[2].listener(event);
@@ -202,6 +325,22 @@ describe('should set interactions', () => {
     });
   });
 
+  it('then call no callback', () => {
+    const interactions = [{
+      id: 'foo',
+      interaction: 'doSomething',
+    }];
+    const callback = jest.fn();
+    const event = { target: map, point: [1, 2] };
+    map.queryRenderedFeatures = () => [];
+
+    setInteractions({ map, interactions, callback });
+    listeners[2].listener(event);
+    jest.runAllTimers();
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
   it('then call callback with mousemove', () => {
     const interactions = [{
       id: 'foo',
@@ -209,6 +348,12 @@ describe('should set interactions', () => {
       trigger: 'mouseover',
     }];
     const callback = jest.fn();
+    const event = { target: map, point: [1, 2] };
+    map.queryRenderedFeatures = () => [{
+      layer: {
+        id: 'foo',
+      },
+    }];
 
     setInteractions({ map, interactions, callback });
 
@@ -219,7 +364,11 @@ describe('should set interactions', () => {
       event,
       map,
       layerId: 'foo',
-      feature: undefined, // PREV_STATE.point has not been defined yet
+      feature: {
+        layer: {
+          id: 'foo',
+        },
+      },
       interaction: interactions[0],
       eventType: 'mouseleave',
     });
@@ -243,33 +392,6 @@ describe('should set interactions', () => {
     });
   });
 
-  it('should get interactions responding to constraints', () => {
-    map.getZoom = () => 3;
-    const interactions = [{
-      id: 'foo',
-      interaction: 'foo',
-      constraints: [{
-        minZoom: 1,
-        maxZoom: 2,
-      }],
-    }, {
-      id: 'foo',
-      interaction: 'foo',
-      constraints: [{
-        minZoom: 2,
-        maxZoom: 3,
-      }],
-    }];
-    const callback = jest.fn();
-
-    setInteractions({ map, interactions, callback });
-    listeners[2].listener(event);
-    listeners[3].listener(event);
-    jest.runAllTimers();
-
-    expect(callback).toHaveBeenCalledTimes(1);
-  });
-
   it('and display pointer cursor', () => {
     const interactions = [{
       id: 'foo',
@@ -285,11 +407,11 @@ describe('should set interactions', () => {
     expect(map.getCanvas).toHaveBeenCalled();
     expect(canvas.style.cursor).toBe('pointer');
 
-    listeners[0].listener(event);
-    listeners[1].listener(event);
+    listeners[0].listener({ target: map, point: [1, 2] });
+    listeners[1].listener({ target: map, point: [1, 2] });
     expect(canvas.style.cursor).toBe('pointer');
 
-    listeners[1].listener(event);
+    listeners[1].listener({ target: map, point: [1, 2] });
     jest.runAllTimers();
 
     expect(map.getCanvas).toHaveBeenCalled();
@@ -472,6 +594,58 @@ it('should check contraints', () => {
   })).toBe(false);
 });
 
+it('should get interactions responding to constraints', () => {
+  const map = {
+    getStyle,
+    getLayoutProperty: jest.fn(() => 'visible'),
+    getZoom: () => 3,
+    queryRenderedFeatures: () => [{
+      layer: {
+        id: 'foo',
+      },
+    }],
+  };
+  const interactions = [{
+    id: 'foo',
+    interaction: 'foo',
+    constraints: [{
+      minZoom: 1,
+      maxZoom: 2,
+    }],
+  }, {
+    id: 'foo',
+    interaction: 'foo',
+    constraints: [{
+      minZoom: 2,
+      maxZoom: 3,
+    }],
+  }];
+  const interaction = getInteractionsOnEvent({ eventType: 'click', map, points: [], interactions });
+  expect(interaction.interactions).toEqual([interactions[1]]);
+});
+
+it('should get multiple interactions', () => {
+  const map = {
+    getStyle,
+    getLayoutProperty: jest.fn(() => 'visible'),
+    getZoom: () => 3,
+    queryRenderedFeatures: () => [{
+      layer: {
+        id: 'foo',
+      },
+    }],
+  };
+  const interactions = [{
+    id: 'foo',
+    interaction: 'foo',
+  }, {
+    id: 'foo',
+    interaction: 'foo',
+  }];
+  const interaction = getInteractionsOnEvent({ eventType: 'click', map, points: [], interactions });
+  expect(interaction.interactions).toEqual(interactions);
+});
+
 it('should call fitBounds', () => {
   const map = { fitBounds: jest.fn() };
 
@@ -499,4 +673,15 @@ it('should call fitBounds', () => {
 
   fitZoom({ feature: [feature], map });
   expect(map.fitBounds).toHaveBeenCalled();
+});
+
+it('should catch error when fetching feature', () => {
+  const map = {
+    queryRenderedFeatures: () => {
+      throw new Error('boum');
+    },
+  };
+  expect(() => getInteractionsOnEvent({
+    map,
+  })).not.toThrow();
 });

--- a/src/modules/Map/services/mapUtils.test.js
+++ b/src/modules/Map/services/mapUtils.test.js
@@ -41,6 +41,11 @@ const getStyle = jest.fn(() => ({
 
 jest.useFakeTimers();
 
+jest.mock('moize', () => ({ serializer }) => fn => (...args) => {
+  serializer(...args);
+  return fn(...args);
+});
+
 it('should get all layers related to main one', () => {
   const map = {
     getStyle,

--- a/src/modules/Map/services/mapUtils.test.js
+++ b/src/modules/Map/services/mapUtils.test.js
@@ -237,7 +237,6 @@ it('should get no interaction on event', () => {
 
 describe('should set interactions', () => {
   let listeners = [];
-  const canvas = { style: {} };
   const map = {
     getStyle,
     getLayoutProperty: jest.fn(() => 'visible'),
@@ -246,7 +245,6 @@ describe('should set interactions', () => {
       listener: listener || id,
       id: listener ? id : null,
     })),
-    getCanvas: jest.fn(() => canvas),
   };
   beforeEach(() => {
     listeners = [];
@@ -263,11 +261,10 @@ describe('should set interactions', () => {
     }];
     const callback = () => {};
     setInteractions({ map, interactions, callback });
-    expect(listeners.length).toBe(4);
-    expect(listeners[0].event).toBe('mouseenter');
-    expect(listeners[1].event).toBe('mouseleave');
-    expect(listeners[2].event).toBe('click');
-    expect(listeners[3].event).toBe('mousedown');
+    expect(listeners.length).toBe(3);
+    expect(listeners[0].event).toBe('click');
+    expect(listeners[1].event).toBe('mousedown');
+    expect(listeners[2].event).toBe('mousemove');
   });
 
   it('with mouseover events', () => {
@@ -278,12 +275,11 @@ describe('should set interactions', () => {
     }];
     const callback = () => {};
     setInteractions({ map, interactions, callback });
-    expect(listeners.length).toBe(4);
-    expect(listeners[0].event).toBe('mouseenter');
-    expect(listeners[1].event).toBe('mouseleave');
-    expect(listeners[2].event).toBe('mouseleave');
-    expect(listeners[3].event).toBe('mousemove');
+    expect(listeners.length).toBe(3);
+    expect(listeners[0].event).toBe('mouseleave');
+    expect(listeners[1].event).toBe('mousemove');
     expect(listeners[0].id).toBe('foo');
+    expect(listeners[2].event).toBe('mousemove');
   });
 
   it('then call callback', () => {
@@ -308,7 +304,7 @@ describe('should set interactions', () => {
     }];
 
     setInteractions({ map, interactions, callback });
-    listeners[2].listener(event);
+    listeners[0].listener(event);
     jest.runAllTimers();
 
     expect(callback).toHaveBeenCalledWith({
@@ -357,7 +353,7 @@ describe('should set interactions', () => {
 
     setInteractions({ map, interactions, callback });
 
-    listeners[2].listener(event);
+    listeners[0].listener(event);
     jest.runAllTimers();
 
     expect(callback).toHaveBeenCalledWith({
@@ -374,10 +370,11 @@ describe('should set interactions', () => {
     });
     callback.mockClear();
 
-    listeners[3].listener(event);
+    listeners[1].listener(event);
     jest.runAllTimers();
 
-    expect(listeners[3].event).toBe('mousemove');
+    expect(listeners[1].event).toBe('mousemove');
+    expect(listeners[1].id).toBe(null);
     expect(callback).toHaveBeenCalledWith({
       event,
       map,
@@ -398,6 +395,8 @@ describe('should set interactions', () => {
       interaction: 'doSomething',
     }];
     const callback = () => {};
+    const canvas = { style: {} };
+    map.getCanvas = jest.fn(() => canvas);
     map.queryRenderedFeatures = () => [{
       layer: {
         id: 'foo',
@@ -406,7 +405,7 @@ describe('should set interactions', () => {
 
     setInteractions({ map, interactions, callback });
 
-    listeners[0].listener({ target: map, point: [1, 2] });
+    listeners[1].listener({ target: map, point: [1, 2] });
     jest.runAllTimers();
 
     expect(map.getCanvas).toHaveBeenCalled();

--- a/src/modules/Map/services/mapUtils.test.js
+++ b/src/modules/Map/services/mapUtils.test.js
@@ -7,6 +7,7 @@ import {
   setInteractions,
   checkContraints,
   fitZoom,
+  PREV_STATE,
 } from './mapUtils';
 
 const getStyle = jest.fn(() => ({
@@ -350,14 +351,14 @@ describe('should set interactions', () => {
     }];
     const callback = jest.fn();
     const event = { target: map, point: [1, 2] };
-    map.queryRenderedFeatures = () => [{
+    PREV_STATE.features = [{
       layer: {
         id: 'foo',
       },
     }];
+    map.queryRenderedFeatures = () => PREV_STATE.features;
 
     setInteractions({ map, interactions, callback });
-
     listeners[0].listener(event);
     jest.runAllTimers();
 
@@ -391,6 +392,19 @@ describe('should set interactions', () => {
           id: 'foo',
         },
       },
+    });
+    callback.mockClear();
+
+    delete PREV_STATE.features;
+    listeners[0].listener(event);
+    jest.runAllTimers();
+
+    expect(callback).toHaveBeenCalledWith({
+      event,
+      map,
+      layerId: 'foo',
+      interaction: interactions[0],
+      eventType: 'mouseleave',
     });
   });
 
@@ -680,15 +694,4 @@ it('should call fitBounds', () => {
 
   fitZoom({ feature: [feature], map });
   expect(map.fitBounds).toHaveBeenCalled();
-});
-
-it('should catch error when fetching feature', () => {
-  const map = {
-    queryRenderedFeatures: () => {
-      throw new Error('boum');
-    },
-  };
-  expect(() => getInteractionsOnEvent({
-    map,
-  })).not.toThrow();
 });

--- a/src/modules/Map/services/mapUtils.test.js
+++ b/src/modules/Map/services/mapUtils.test.js
@@ -335,7 +335,7 @@ describe('should set interactions', () => {
     map.queryRenderedFeatures = () => [];
 
     setInteractions({ map, interactions, callback });
-    listeners[2].listener(event);
+    listeners[0].listener(event);
     jest.runAllTimers();
 
     expect(callback).not.toHaveBeenCalled();
@@ -398,6 +398,11 @@ describe('should set interactions', () => {
       interaction: 'doSomething',
     }];
     const callback = () => {};
+    map.queryRenderedFeatures = () => [{
+      layer: {
+        id: 'foo',
+      },
+    }];
 
     setInteractions({ map, interactions, callback });
 
@@ -407,9 +412,7 @@ describe('should set interactions', () => {
     expect(map.getCanvas).toHaveBeenCalled();
     expect(canvas.style.cursor).toBe('pointer');
 
-    listeners[0].listener({ target: map, point: [1, 2] });
-    listeners[1].listener({ target: map, point: [1, 2] });
-    expect(canvas.style.cursor).toBe('pointer');
+    map.queryRenderedFeatures = () => [];
 
     listeners[1].listener({ target: map, point: [1, 2] });
     jest.runAllTimers();

--- a/src/modules/Visualizer/services/warningZoom.js
+++ b/src/modules/Visualizer/services/warningZoom.js
@@ -1,4 +1,4 @@
-import { getLayers } from '../../Map/services/mapUtils';
+import { getRelatedLayers } from '../../Map/services/mapUtils';
 
 export function getMinMax (values, minThreshold = 0, maxThreshold = 24) {
   return values.reduce((
@@ -16,7 +16,7 @@ export function displayWarningAccordingToZoom (map, layer) {
   const currentZoom = map.getZoom();
 
   const layers = layer.layers.reduce((prev, layerId) =>
-    [...prev, ...getLayers(map, layerId)], []);
+    [...prev, ...getRelatedLayers(map, layerId)], []);
 
   const sourcesIds = [...new Set(layers.reduce((prev, { source }) => [...prev, source], []))];
 


### PR DESCRIPTION
https://github.com/Terralego/terra-front/issues/37

Interactions take lot of cpu because of layers check. We get perfs by memoizing the list of layers and refreshing it when all layers list change.