### PR TITLE
Utils to get custom layers ordered as layers tree

### DIFF
--- a/src/modules/Visualizer/services/layersTreeUtils.js
+++ b/src/modules/Visualizer/services/layersTreeUtils.js
@@ -169,6 +169,23 @@ export const resetFilters = (map, layersTreeState) => {
   });
 };
 
+const flattenLayersTreeLayersId = layersTree => layersTree.reduce((all, { group, layers }) => [
+  ...all,
+  ...(group ? flattenLayersTreeLayersId(layers) : layers),
+], []);
+
+export const sortCustomLayers = (customLayers, layersTree) => {
+  const newCustomLayers = [...customLayers];
+  const flattenLayersTree = flattenLayersTreeLayersId(layersTree);
+  flattenLayersTree.forEach(layerId => {
+    const pos = newCustomLayers.findIndex(({ id }) => id === layerId);
+    if (pos > -1) {
+      newCustomLayers.push(...newCustomLayers.splice(pos, 1));
+    }
+  });
+  return newCustomLayers;
+};
+
 export default {
   initLayersStateAction,
   setLayerStateAction,
@@ -177,4 +194,5 @@ export default {
   hasWidget,
   filterFeatures,
   resetFilters,
+  sortCustomLayers,
 };

--- a/src/modules/Visualizer/services/layersTreeUtils.test.js
+++ b/src/modules/Visualizer/services/layersTreeUtils.test.js
@@ -8,6 +8,7 @@ import {
   isCluster,
   filterFeatures,
   resetFilters,
+  sortCustomLayers,
   INITIAL_FILTERS,
 } from './layersTreeUtils';
 
@@ -376,4 +377,46 @@ it('should set group state', () => {
   expect(newLayersTreeState.get(layer.layers[1])).toEqual({
     active: false,
   });
+});
+
+it('should sort custom layers', () => {
+  const customLayers = [{
+    id: '1',
+  }, {
+    id: '2',
+  }, {
+    id: '3',
+  }, {
+    id: '4',
+  }, {
+    id: '5',
+  }, {
+    id: '6',
+  }];
+  const lT = [{
+    layers: ['4', '2', '7'],
+  }, {
+    group: 'foo',
+    layers: [{
+      layers: ['3', '5'],
+    }, {
+      group: 'bar',
+      layers: [{
+        layers: ['1', '2'],
+      }],
+    }],
+  }];
+  expect(sortCustomLayers(customLayers, lT)).toEqual([{
+    id: '6',
+  }, {
+    id: '4',
+  }, {
+    id: '3',
+  }, {
+    id: '5',
+  }, {
+    id: '1',
+  }, {
+    id: '2',
+  }]);
 });


### PR DESCRIPTION
This utility will first be used in project then in Visualizer component. It helps to sort custom layers in the same order than the layers tree.