### PR TITLE
Better consistency across project

### DIFF
--- a/src/modules/Auth/components/AuthProvider/index.js
+++ b/src/modules/Auth/components/AuthProvider/index.js
@@ -8,7 +8,9 @@ import {
   invalidToken,
   createToken,
 } from '../../services/auth';
-import { Provider } from '../../services/context';
+import context from '../../services/context';
+
+const { Provider } = context;
 
 export class AuthProvider extends React.Component {
   constructor (props) {

--- a/src/modules/Auth/components/AuthProvider/index.test.js
+++ b/src/modules/Auth/components/AuthProvider/index.test.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import AuthProvider from '.';
-import { Consumer } from '../../services/context';
+import context from '../../services/context';
 import Auth from '../../services/auth';
+
+const { Consumer } = context;
 
 const MOCKED_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7ImlkIjo0Mn0sImV4cCI6MTUxNjIzOTAyMn0.mPABaxD6A5yFiIFWjNDFFEhtDsrtDPVsDKHCW6ljCNs';
 

--- a/src/modules/Auth/services/context.js
+++ b/src/modules/Auth/services/context.js
@@ -1,10 +1,7 @@
 import React from 'react';
+import connect from 'react-ctx-connect';
 
-import connect from '../../../utils/connect';
-
-const context = React.createContext();
-export const { Provider, Consumer } = context;
-
+export const context = React.createContext();
 export const connectAuthProvider = connect(context);
 
 export default context;

--- a/src/modules/State/Hash/index.js
+++ b/src/modules/State/Hash/index.js
@@ -1,4 +1,4 @@
 import StateProvider from '../StateProvider';
-import { withHashState } from './withHashState';
+import withHashState from './withHashState';
 
-export default withHashState()(StateProvider);
+export default withHashState(StateProvider);

--- a/src/modules/State/Hash/withHashState.js
+++ b/src/modules/State/Hash/withHashState.js
@@ -16,7 +16,7 @@ export const DEFAULT_OPTIONS = {
 /**
  * Decorator for getting an initialState from hash.
  */
-export const withHashState = () => WrappedComponent =>
+export const withHashState = WrappedComponent => {
   class WithHashState extends React.Component {
     static propTypes = {
       /** @param {boolean} [listenHash=true] If initialState should be update when hash changes */
@@ -80,6 +80,11 @@ export const withHashState = () => WrappedComponent =>
         />
       );
     }
-  };
+  }
+
+  const name = WrappedComponent.displayName || WrappedComponent.name;
+  WithHashState.displayName = `withHashState(${name})`;
+  return WithHashState;
+};
 
 export default withHashState;

--- a/src/modules/State/Hash/withHashState.test.js
+++ b/src/modules/State/Hash/withHashState.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import withHashState from './withHashState';
 
 const Component = jest.fn(() => null);
-const ComponentWithHash = withHashState()(Component);
+const ComponentWithHash = withHashState(Component);
 
 it('should not set listeners', () => {
   jest.spyOn(window, 'addEventListener');

--- a/src/modules/TerraFrontProvider.js
+++ b/src/modules/TerraFrontProvider.js
@@ -1,6 +1,5 @@
 import React from 'react';
-
-import connect from '../utils/connect';
+import connect from 'react-ctx-connect';
 
 export const context = React.createContext();
 

--- a/src/utils/connect.js
+++ b/src/utils/connect.js
@@ -1,3 +1,0 @@
-import connect from 'react-ctx-connect';
-
-export default connect;


### PR DESCRIPTION
- Remove deep scoped withHashState (not needed)
- Remove `utils/connect.js` that was only used once, prefer direct import `react-ctx-connect`
- Use same approach of using context in `AuthProvider/index.js` as the rest of the project