### PR TITLE
Rename the legend radius to diameter

### DIFF
--- a/src/modules/Map/InteractiveMap/components/Legend/Legend.js
+++ b/src/modules/Map/InteractiveMap/components/Legend/Legend.js
@@ -8,7 +8,7 @@ import CustomComponents from './CustomComponents';
 import Circle from './components/Circle';
 import Rect from './components/Rect';
 
-const DEFAULT_RADIUS = 16;
+const DEFAULT_DIAMETER = 16;
 
 export const Legend = ({
   title,
@@ -20,8 +20,8 @@ export const Legend = ({
   history,
   stackedCircles,
 }) => {
-  const biggestRadius = items.reduce((int, item) =>
-    Math.max(int, item.radius || DEFAULT_RADIUS), 0);
+  const biggestDiameter = items.reduce((int, item) =>
+    Math.max(int, item.diameter || DEFAULT_DIAMETER), 0);
 
   return (
     <div className={`tf-legend tf-legend--level-${level}`}>
@@ -35,7 +35,7 @@ export const Legend = ({
           'tf-legend__list',
           { 'tf-legend__stacked-circles': stackedCircles },
         )}
-        style={stackedCircles ? { height: biggestRadius } : null}
+        style={stackedCircles ? { height: biggestDiameter } : null}
       >
         {content && (
           <Template
@@ -51,7 +51,7 @@ export const Legend = ({
           color,
           items: subItems,
           shape = 'square',
-          radius = DEFAULT_RADIUS,
+          diameter = DEFAULT_DIAMETER,
         }, index) => {
           if (subItems) {
             return (
@@ -83,11 +83,11 @@ export const Legend = ({
             >
               <div
                 className="tf-legend__symbol-container"
-                style={{ width: shape === 'circle' ? biggestRadius : DEFAULT_RADIUS * 2 }}
+                style={{ width: shape === 'circle' ? biggestDiameter : DEFAULT_DIAMETER * 2 }}
               >
                 {shape === 'circle'
-                  ? <Circle color={color} size={radius} />
-                  : <Rect color={color} size={DEFAULT_RADIUS} />}
+                  ? <Circle color={color} size={diameter} />
+                  : <Rect color={color} size={DEFAULT_DIAMETER} />}
               </div>
               <div className="tf-legend__label">{label}</div>
             </div>
@@ -107,7 +107,7 @@ Legend.propTypes = {
     color: PropTypes.string,
     items: PropTypes.array,
     shape: PropTypes.string,
-    radius: PropTypes.number,
+    diameter: PropTypes.number,
     template: PropTypes.string,
   })),
   content: PropTypes.string,

--- a/src/modules/Map/InteractiveMap/components/Legend/Legend.js
+++ b/src/modules/Map/InteractiveMap/components/Legend/Legend.js
@@ -51,7 +51,8 @@ export const Legend = ({
           color,
           items: subItems,
           shape = 'square',
-          diameter = DEFAULT_DIAMETER,
+          radius,
+          diameter = radius || DEFAULT_DIAMETER,
         }, index) => {
           if (subItems) {
             return (

--- a/src/stories/modules/Map/Legend.stories.js
+++ b/src/stories/modules/Map/Legend.stories.js
@@ -130,17 +130,17 @@ stories.add('Circles', () => (
             label: 'exercitation ullamco',
             color: 'white',
             shape: 'circle',
-            radius: 30,
+            diameter: 30,
           }, {
             label: 'laboris nisi ut aliquip',
             color: 'white',
             shape: 'circle',
-            radius: 15,
+            diameter: 15,
           }, {
             label: 'ex ea commodo consequat',
             color: 'white',
             shape: 'circle',
-            radius: 5,
+            diameter: 5,
           },
         ]}
       />
@@ -171,17 +171,17 @@ stories.add('Stacked', () => (
             label: 'exercitation ullamco',
             color: 'white',
             shape: 'circle',
-            radius: 20,
+            diameter: 20,
           }, {
             label: 'laboris nisi ut aliquip',
             color: 'white',
             shape: 'circle',
-            radius: 15,
+            diameter: 15,
           }, {
             label: 'ex ea commodo consequat',
             color: 'white',
             shape: 'circle',
-            radius: 10,
+            diameter: 10,
           }],
         }]}
       />


### PR DESCRIPTION
Be careful, this PR contains a breacking change.

Proposition to rename radius to diameter because when the svg is created, it uses the width and height attributes that correspond to the diameter