### PR TITLE
Fix display tooltip behavior

### DIFF
--- a/src/modules/Map/InteractiveMap/InteractiveMap.js
+++ b/src/modules/Map/InteractiveMap/InteractiveMap.js
@@ -175,7 +175,8 @@ export class InteractiveMap extends React.Component {
     this.mouseMoveListener = ({ target }) => {
       if (!this.map) return;
 
-      if (isOverMap(target, this.map)) return;
+      this.isPointerOverMap = isOverMap(target, this.map);
+      if (this.isPointerOverMap) return;
 
       /**
        * If event is NOT from map then pointer is moving ouside of the map :
@@ -367,7 +368,10 @@ export class InteractiveMap extends React.Component {
     className,
   }) => {
     const { history } = this.props;
-    const { map } = this;
+    const { map, isPointerOverMap } = this;
+
+    if (isPointerOverMap === false) return;
+
     const zoom = map.getZoom();
     const container = element || generateTooltipContainer({
       fetchProperties,

--- a/src/modules/Map/InteractiveMap/InteractiveMap.test.js
+++ b/src/modules/Map/InteractiveMap/InteractiveMap.test.js
@@ -843,6 +843,7 @@ describe('Interactions', () => {
       getCanvasContainer: () => {},
       getContainer: () => ({
         contains: () => true,
+        querySelectorAll: () => [],
       }),
     };
 
@@ -853,6 +854,7 @@ describe('Interactions', () => {
       getCanvasContainer: () => {},
       getContainer: () => ({
         contains: () => false,
+        querySelectorAll: () => [],
       }),
     };
 

--- a/src/modules/Map/InteractiveMap/InteractiveMap.test.js
+++ b/src/modules/Map/InteractiveMap/InteractiveMap.test.js
@@ -865,6 +865,39 @@ describe('Interactions', () => {
     expect(popup3.remove).toHaveBeenCalled();
   });
 
+  it('should cancel tooltip display when mouse isn\'t over map anymore', () => {
+    const instance = new InteractiveMap({
+      onInit () {},
+    });
+    instance.setState = () => null;
+    instance.componentDidMount();
+
+    const event = {
+      target: {},
+    };
+
+    instance.map = {
+      getZoom: jest.fn(() => 14),
+      getCanvasContainer: () => {},
+      getContainer: () => ({
+        contains: () => true,
+        querySelectorAll: () => [{
+          contains: () => true,
+        }],
+      }),
+    };
+
+    instance.mouseMoveListener(event);
+    instance.displayTooltip({
+      layerId: 'foo',
+      features: [{ properties: {} }],
+      event: { lngLat: { lng: 3, lat: 4 } },
+      template: 'bar',
+    });
+
+    expect(instance.popups.size).toBe(0);
+  });
+
   it('should remove listener', () => {
     const instance = new InteractiveMap({});
     instance.mouseMoveListener = () => null;


### PR DESCRIPTION
### What was wrong

When moving mouse from a map feature having a tooltip, to an element that was inside the map but not the map properly, the tooltip was shown.

Put another way: map feature tooltips do not disapear when mouse pointer is over map controls.

![image](https://user-images.githubusercontent.com/1846633/64430883-82976d80-d0b9-11e9-88fe-753ca86fa714.png)
![image](https://user-images.githubusercontent.com/1846633/64431366-92638180-d0ba-11e9-9baf-fe4f18af82e6.png)


### What does this PR

- Add a fix to consider having mouse over map controls as not really beeing *over* the map.
- Add a fuse to avoid displaying a feature tooltip if mouse pointer is not over the map anymore.
