### PR TITLE
Fix updating values of MultiSelect

### DIFF
--- a/src/modules/Forms/Controls/MultiSelect.js
+++ b/src/modules/Forms/Controls/MultiSelect.js
@@ -47,6 +47,13 @@ export class MultiSelect extends React.Component {
     this.updateItems();
   }
 
+  componentDidUpdate ({ values: prevValues }) {
+    const { values } = this.props;
+    if (prevValues !== values) {
+      this.updateItems();
+    }
+  }
+
   handleChange = item => {
     const { value, onChange } = this.props;
     const newValue = value.includes(item)


### PR DESCRIPTION
WHen updating values, `state.items` is not updated leaving a MultiSelect populated by `fetchPropertyValues()` empty