### PR TITLE
Update dataTable sorting only where there are the same columns

### DIFF
--- a/src/modules/Table/components/Table/Table.js
+++ b/src/modules/Table/components/Table/Table.js
@@ -59,10 +59,10 @@ export class Table extends React.Component {
     lastSort: [],
   };
 
-  componentDidUpdate ({ data: prevData }) {
-    const { data } = this.props;
+  componentDidUpdate ({ data: prevData, columns: prevColumns }) {
+    const { data, columns } = this.props;
     const { lastSort } = this.state;
-    if (data !== prevData) {
+    if (data !== prevData && columns === prevColumns) {
       this.sortColumn(...lastSort);
     }
   }

--- a/src/modules/Table/components/Table/Table.test.js
+++ b/src/modules/Table/components/Table/Table.test.js
@@ -100,7 +100,7 @@ it('should update sorting', () => {
   const instance = new Table(props);
   instance.sortColumn = jest.fn();
   instance.state.lastSort = [1, 2];
-  instance.componentDidUpdate({ data: [] });
+  instance.componentDidUpdate({ data: [], columns: props.columns });
   expect(instance.sortColumn).toHaveBeenCalledWith(1, 2);
 });
 


### PR DESCRIPTION
Before my request, each time we are updating data, the table keeps the last order defined by the user or the app.  
The edge case is the moment when we are totally changing data **and** columns. It's necessary to not keep the last order because:
1/ There is probably no sorting link between the table before and after
2/ The app crashes if we sort a X column that is greater than the length of the columns of the next table.  