### PR TITLE
Improve insertions of layers

### DIFF
--- a/src/modules/Map/Map/Map.test.js
+++ b/src/modules/Map/Map/Map.test.js
@@ -3,7 +3,7 @@ import renderer from 'react-test-renderer';
 import { shallow } from 'enzyme';
 import mapboxgl from 'mapbox-gl';
 
-import { MapComponent as Map, getLayerBeforeId } from './Map';
+import { MapComponent as Map } from './Map';
 import { updateCluster } from '../services/cluster';
 
 const props = {
@@ -375,52 +375,6 @@ it('should create layers', () => {
     id: 'layer5',
     type: 'symbol',
   }]);
-});
-
-it('should get layer before', () => {
-  expect(getLayerBeforeId('line', [{
-    type: 'line',
-    id: 'a',
-  }, {
-    type: 'line',
-    id: 'b',
-  }, {
-    type: 'line',
-    id: 'c',
-  }, {
-    type: 'circle',
-    id: 'd',
-  }])).toBe('d');
-
-  expect(getLayerBeforeId('circle', [{
-    type: 'line',
-    id: 'a',
-  }, {
-    type: 'line',
-    id: 'b',
-  }, {
-    type: 'line',
-    id: 'c',
-  }, {
-    type: 'circle',
-    id: 'd',
-  }])).toBe(undefined);
-
-  expect(getLayerBeforeId('fill', [{
-    type: 'fill',
-    id: 'a',
-  }, {
-    type: 'line',
-    id: 'b',
-  }, {
-    type: 'line',
-    id: 'c',
-  }, {
-    type: 'circle',
-    id: 'd',
-  }])).toBe('b');
-
-  expect(getLayerBeforeId('fill', [])).toBe(undefined);
 });
 
 it('should create cluster layer', () => {

--- a/src/modules/Map/services/mapUtils.js
+++ b/src/modules/Map/services/mapUtils.js
@@ -214,10 +214,32 @@ export function fitZoom ({ feature, map, padding = 0 }) {
   map.fitBounds(bbox({ type: 'FeatureCollection', features }), { padding });
 }
 
+const getTypeBefore = (type, types = LAYER_TYPES_ORDER) => {
+  const index = types.findIndex(t => t === type) - 1;
+  return index > -1 ? types[index] : undefined;
+};
+
+
+/**
+ * Returns
+ * - `layers` first layer id with the requested `type`
+ * - or `layers` first layer id with the first type available before the requested `type`
+ * - or `undefined`
+ *
+ * @param {object} type The type of a layer
+ * @param {array} layers The list of layers to find the requested id
+ * @return {string|undefined} The id of the requested layer or undefined if none found.
+ */
 export const getLayerBeforeId = (type, layers) => {
   const sameTypes = layers.filter(layer => type === layer.type);
 
-  if (!sameTypes.length) return undefined;
+  if (!sameTypes.length) {
+    const newType = getTypeBefore(type);
+    if (newType) {
+      return getLayerBeforeId(newType, layers);
+    }
+    return undefined;
+  }
 
   const lastOfSameType = sameTypes[sameTypes.length - 1];
 

--- a/src/modules/Map/services/mapUtils.js
+++ b/src/modules/Map/services/mapUtils.js
@@ -231,7 +231,9 @@ const getTypeBefore = (type, types = LAYER_TYPES_ORDER) => {
  * @return {string|undefined} The id of the requested layer or undefined if none found.
  */
 export const getLayerBeforeId = (type, layers) => {
-  const sameTypes = layers.filter(layer => type === layer.type);
+  const isDrawLayer = layer => layer.id.startsWith('gl-draw');
+
+  const sameTypes = layers.filter(layer => type === layer.type && !isDrawLayer(layer));
 
   if (!sameTypes.length) {
     const newType = getTypeBefore(type);

--- a/src/modules/Map/services/mapUtils.js
+++ b/src/modules/Map/services/mapUtils.js
@@ -4,6 +4,7 @@ import moize from 'moize';
 import { PREFIXES } from './cluster';
 
 export const PREV_STATE = {};
+export const LAYER_TYPES_ORDER = ['background', 'raster', 'hillshade', 'heatmap', 'fill', 'fill-extrusion', 'line', 'circle', 'symbol'];
 
 export const getRelatedLayers = moize({
   serializer: (map, layerId) => `${layerId}${map.getStyle().layers.map(id => id).join('')}`,
@@ -213,7 +214,28 @@ export function fitZoom ({ feature, map, padding = 0 }) {
   map.fitBounds(bbox({ type: 'FeatureCollection', features }), { padding });
 }
 
+export const getLayerBeforeId = (type, layers) => {
+  const sameTypes = layers.filter(layer => type === layer.type);
+
+  if (!sameTypes.length) return undefined;
+
+  const lastOfSameType = sameTypes[sameTypes.length - 1];
+
+  const pos = layers.findIndex(({ id }) => id === lastOfSameType.id) + 1;
+
+  return layers[pos] && layers[pos].id;
+};
+
+export const getOrderedLayers = (layers, layersTypes = LAYER_TYPES_ORDER) => {
+  const orderedLayers = [...layers];
+  return orderedLayers.sort(({ type: typeA }, { type: typeB }) => {
+    if (typeA === typeB) return 0;
+    return layersTypes.indexOf(typeA) - layersTypes.indexOf(typeB);
+  });
+};
+
 export default {
+  LAYER_TYPES_ORDER,
   toggleLayerVisibility,
   getOpacityProperty,
   setLayerOpacity,
@@ -221,4 +243,6 @@ export default {
   setInteractions,
   checkContraints,
   fitZoom,
+  getLayerBeforeId,
+  getOrderedLayers,
 };

--- a/src/modules/Map/services/mapUtils.test.js
+++ b/src/modules/Map/services/mapUtils.test.js
@@ -8,6 +8,8 @@ import {
   checkContraints,
   fitZoom,
   PREV_STATE,
+  getLayerBeforeId,
+  getOrderedLayers,
 } from './mapUtils';
 
 const getStyle = jest.fn(() => ({
@@ -694,4 +696,65 @@ it('should call fitBounds', () => {
 
   fitZoom({ feature: [feature], map });
   expect(map.fitBounds).toHaveBeenCalled();
+});
+
+it('should get layer before', () => {
+  expect(getLayerBeforeId('line', [{
+    type: 'line',
+    id: 'a',
+  }, {
+    type: 'line',
+    id: 'b',
+  }, {
+    type: 'line',
+    id: 'c',
+  }, {
+    type: 'circle',
+    id: 'd',
+  }])).toBe('d');
+
+  expect(getLayerBeforeId('circle', [{
+    type: 'line',
+    id: 'a',
+  }, {
+    type: 'line',
+    id: 'b',
+  }, {
+    type: 'line',
+    id: 'c',
+  }, {
+    type: 'circle',
+    id: 'd',
+  }])).toBe(undefined);
+
+  expect(getLayerBeforeId('fill', [{
+    type: 'fill',
+    id: 'a',
+  }, {
+    type: 'line',
+    id: 'b',
+  }, {
+    type: 'line',
+    id: 'c',
+  }, {
+    type: 'circle',
+    id: 'd',
+  }])).toBe('b');
+
+  expect(getLayerBeforeId('fill', [])).toBe(undefined);
+});
+
+it('should get orderedLayers', () => {
+  const layers = [
+    { type: 'fill' },
+    { type: 'hillshade' },
+    { type: 'symbol' },
+    { type: 'circle' },
+  ];
+  expect(getOrderedLayers(layers)).toEqual([
+    { type: 'hillshade' },
+    { type: 'fill' },
+    { type: 'circle' },
+    { type: 'symbol' },
+  ]);
 });


### PR DESCRIPTION
When inserting/deleting layers from the map, the map keeps a certain order driven by the type of layer.
The order is defined by this following constante `LAYERS_TYPES = ['background', 'raster', 'hillshade', 'heatmap', 'fill', 'fill-extrusion', 'line', 'circle', 'symbol']`; <- Left at the bottom; Right at the top.

1/ Move certain functions from the Map component to MapUtils
2/ Keep a better order
For example, if we try to insert a layer with a `fill` type and there isn't other layer with this type, this layer will be positioned after **all layers**. With this PR, it would try to insert it after a `heatmap` type layer, if there is not `heatmap` type layer, it would try with `hillshade` type layer, etc.
3/ No consideration for all `draw map Layer`. These must stay on top and not influence the order of others
