### PR TITLE
Expand click area on the whole button for certain map controls

### DIFF
--- a/src/modules/Map/InteractiveMap/components/BackgroundStyles/BackgroundStyles.js
+++ b/src/modules/Map/InteractiveMap/components/BackgroundStyles/BackgroundStyles.js
@@ -40,33 +40,34 @@ export class BackgroundStyles extends AbstractMapControl {
       <Tooltip
         content={translate('terralego.map.backgroundstyles_control.button_label')}
       >
-        <button
-          className="mapboxgl-ctrl-icon"
-          type="button"
-        >
-          <Popover
-            className="popoverPos"
-            content={(
-              <div className="radioGroup">
-                <RadioGroup
-                  onChange={onChange}
-                  selectedValue={selected}
-                >
-                  {styles.map(({ label, url }) => (
-                    <Radio
-                      className="bgLayer-radio"
-                      key={`${label}${url}`}
-                      label={label}
-                      value={url}
-                    />
-                  ))}
-                </RadioGroup>
-              </div>
+
+        <Popover
+          className="popoverPos"
+          content={(
+            <div className="radioGroup">
+              <RadioGroup
+                onChange={onChange}
+                selectedValue={selected}
+              >
+                {styles.map(({ label, url }) => (
+                  <Radio
+                    className="bgLayer-radio"
+                    key={`${label}${url}`}
+                    label={label}
+                    value={url}
+                  />
+                ))}
+              </RadioGroup>
+            </div>
           )}
+        >
+          <button
+            className="mapboxgl-ctrl-icon"
+            type="button"
           >
             <Icon icon="layers" />
-          </Popover>
-        </button>
+          </button>
+        </Popover>
       </Tooltip>
     );
   }

--- a/src/modules/Map/InteractiveMap/components/BackgroundStyles/__snapshots__/BackgroundStyles.test.js.snap
+++ b/src/modules/Map/InteractiveMap/components/BackgroundStyles/__snapshots__/BackgroundStyles.test.js.snap
@@ -4,17 +4,17 @@ exports[`should render correctly 1`] = `
 <span
   className="Tooltip"
 >
-  <button
-    className="mapboxgl-ctrl-icon"
-    type="button"
+  <span
+    className="Popover"
   >
-    <span
-      className="Popover"
+    <button
+      className="mapboxgl-ctrl-icon"
+      type="button"
     >
       <span>
         Icon
       </span>
-    </span>
-  </button>
+    </button>
+  </span>
 </span>
 `;

--- a/src/modules/Map/Map/components/PrintControl/PrintControl.js
+++ b/src/modules/Map/Map/components/PrintControl/PrintControl.js
@@ -133,23 +133,24 @@ export class PrintControl extends AbstractMapControl {
       <Tooltip
         content={translate('terralego.map.print_control.button_label')}
       >
-        <button
-          className="mapboxgl-ctrl-icon"
-          type="button"
-          aria-label={translate('terralego.map.print_control.button_label')}
+
+        <Popover
+          className="popoverPos"
+          position={PopoverPosition.AUTO_START}
+          interactionKind={PopoverInteractionKind.CLICK_TARGET_ONLY}
+          onInteraction={this.handleInteraction}
+          isOpen={isOpen}
+          ref={this.popoverRef}
+          content={this.renderContent()}
         >
-          <Popover
-            className="popoverPos"
-            position={PopoverPosition.AUTO_START}
-            interactionKind={PopoverInteractionKind.CLICK_TARGET_ONLY}
-            onInteraction={this.handleInteraction}
-            isOpen={isOpen}
-            ref={this.popoverRef}
-            content={this.renderContent()}
+          <button
+            className="mapboxgl-ctrl-icon"
+            type="button"
+            aria-label={translate('terralego.map.print_control.button_label')}
           >
             <Icon icon="print" />
-          </Popover>
-        </button>
+          </button>
+        </Popover>
       </Tooltip>
     );
   }

--- a/src/modules/Map/Map/components/PrintControl/__snapshots__/PrintControl.test.js.snap
+++ b/src/modules/Map/Map/components/PrintControl/__snapshots__/PrintControl.test.js.snap
@@ -11,18 +11,17 @@ exports[`should render 1`] = `
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
-    <button
-      aria-label="Print to PDF"
-      className="mapboxgl-ctrl-icon"
-      tabIndex={0}
-      type="button"
+    <span
+      className="bp3-popover-wrapper popoverPos"
     >
       <span
-        className="bp3-popover-wrapper popoverPos"
+        className="bp3-popover-target"
+        onClick={[Function]}
       >
-        <span
-          className="bp3-popover-target"
-          onClick={[Function]}
+        <button
+          aria-label="Print to PDF"
+          className="mapboxgl-ctrl-icon"
+          type="button"
         >
           <span
             className="bp3-icon bp3-icon-print"
@@ -43,9 +42,9 @@ exports[`should render 1`] = `
               />
             </svg>
           </span>
-        </span>
+        </button>
       </span>
-    </button>
+    </span>
   </span>
 </span>
 `;
@@ -61,18 +60,17 @@ exports[`should render exporting 1`] = `
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
-    <button
-      aria-label="Print to PDF"
-      className="mapboxgl-ctrl-icon"
-      tabIndex={0}
-      type="button"
+    <span
+      className="bp3-popover-wrapper popoverPos"
     >
       <span
-        className="bp3-popover-wrapper popoverPos"
+        className="bp3-popover-target"
+        onClick={[Function]}
       >
-        <span
-          className="bp3-popover-target"
-          onClick={[Function]}
+        <button
+          aria-label="Print to PDF"
+          className="mapboxgl-ctrl-icon"
+          type="button"
         >
           <span
             className="bp3-icon bp3-icon-print"
@@ -93,9 +91,9 @@ exports[`should render exporting 1`] = `
               />
             </svg>
           </span>
-        </span>
+        </button>
       </span>
-    </button>
+    </span>
   </span>
 </span>
 `;

--- a/src/modules/Map/Map/components/ShareControl/ShareControl.js
+++ b/src/modules/Map/Map/components/ShareControl/ShareControl.js
@@ -110,20 +110,14 @@ export class ShareControl extends AbstractMapControl {
       <Tooltip
         content={translate('terralego.map.share_control.link')}
       >
-        <button
-          className="mapboxgl-ctrl-icon"
-          type="button"
-          onClick={this.generateHashString}
-          aria-label={translate('terralego.map.share_control.link')}
-        >
-          <Popover
-            position={PopoverPosition.RIGHT}
-            content={(
-              <ControlGroup
-                className="mapboxgl-ctrl-share"
-                fill
-              >
-                {link && (
+        <Popover
+          position={PopoverPosition.RIGHT}
+          content={(
+            <ControlGroup
+              className="mapboxgl-ctrl-share"
+              fill
+            >
+              {link && (
                 <>
                   <input
                     className="bp3-input"
@@ -143,30 +137,36 @@ export class ShareControl extends AbstractMapControl {
                     {copySuccess && translate('terralego.map.share_control.copied')}
                   </Popover>
                 </>
-                )}
-                {['twitter', 'facebook', 'linkedin'].map(network => this.props[network] && (
-                  <Tooltip
-                    className={`share__btn-tooltip share__btn-tooltip--${network}`}
-                    key={network}
-                    content={translate('terralego.map.share_control.share', {
-                      context: network.charAt(0).toUpperCase() + network.slice(1),
-                    })}
-                    openOnTargetFocus={false}
-                  >
-                    <Button
-                      className={`share__btn share__btn--${network}`}
-                      onClick={this.share(network)}
-                    >
-                      <img src={icon(network)} alt={network} />
-                    </Button>
-                  </Tooltip>
-                ))}
-              </ControlGroup>
               )}
+              {['twitter', 'facebook', 'linkedin'].map(network => this.props[network] && (
+              <Tooltip
+                className={`share__btn-tooltip share__btn-tooltip--${network}`}
+                key={network}
+                content={translate('terralego.map.share_control.share', {
+                  context: network.charAt(0).toUpperCase() + network.slice(1),
+                })}
+                openOnTargetFocus={false}
+              >
+                <Button
+                  className={`share__btn share__btn--${network}`}
+                  onClick={this.share(network)}
+                >
+                  <img src={icon(network)} alt={network} />
+                </Button>
+              </Tooltip>
+              ))}
+            </ControlGroup>
+              )}
+        >
+          <button
+            className="mapboxgl-ctrl-icon"
+            type="button"
+            onClick={this.generateHashString}
+            aria-label={translate('terralego.map.share_control.link')}
           >
             <Icon icon="share" />
-          </Popover>
-        </button>
+          </button>
+        </Popover>
       </Tooltip>
     );
   }


### PR DESCRIPTION
Before this pull request, the click area is only accessible on the icon