### PR TITLE
Fix condition to reseting sortedIndexMap value

### DIFF
--- a/src/modules/Table/components/Table/Table.js
+++ b/src/modules/Table/components/Table/Table.js
@@ -65,7 +65,7 @@ export class Table extends React.Component {
     if (data !== prevData && columns === prevColumns) {
       this.sortColumn(...lastSort);
     }
-    if (Number.isSafeInteger(sortedIndexMap) && data !== prevData && columns !== prevColumns) {
+    if (sortedIndexMap && data !== prevData && columns !== prevColumns) {
       this.resetSortedIndexMap();
     }
   }


### PR DESCRIPTION
I thought `sortedIndexMap` was a number, actually it's an array of number or null. My bad.