### PR TITLE
Update Mapbox gl package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8379,9 +8379,9 @@
       }
     },
     "earcut": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.1.tgz",
-      "integrity": "sha512-5jIMi2RB3HtGPHcYd9Yyl0cczo84y+48lgKPxMijliNQaKAHEZJbdzLmKmdxG/mCdS/YD9DQ1gihL8mxzR0F9w=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.2.tgz",
+      "integrity": "sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -10911,9 +10911,9 @@
       }
     },
     "gl-matrix": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.1.0.tgz",
-      "integrity": "sha512-526NA+3EA+ztAQi0IZpSWiM0fyQXIp7IbRvfJ4wS/TjjQD0uv0fVybXwwqqSOlq33UckivI0yMDlVtboWm3k7A=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.2.1.tgz",
+      "integrity": "sha512-YYVO8jUSf6+SakL4AJmx9Jc7zAZhkJQ+WhdtX3VQe5PJdCOX6/ybY4x1vk+h94ePnjRn6uml68+QxTAJneUpvA=="
     },
     "glob": {
       "version": "7.1.3",
@@ -14694,9 +14694,9 @@
       }
     },
     "mapbox-gl": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.5.0.tgz",
-      "integrity": "sha512-seTQUttE7XaL93on+zfLv06HmROsIdTh3riEPrBdbylSirLmBRnofG+iV873ZbJQElf+d2USyHpWAJm37RehEQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.7.0.tgz",
+      "integrity": "sha512-iVZQUdhZzeVCE8VlELo24GfGqhAzjouiJl1K4rcfk9mtyJLCbWHlzGT6H5Bs61A/3NQXsSx54GdJXAWvebtFFg==",
       "requires": {
         "@mapbox/geojson-rewind": "^0.4.0",
         "@mapbox/geojson-types": "^1.0.2",
@@ -14708,7 +14708,7 @@
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
         "csscolorparser": "~1.0.2",
-        "earcut": "^2.2.0",
+        "earcut": "^2.2.2",
         "geojson-vt": "^3.2.1",
         "gl-matrix": "^3.0.0",
         "grid-index": "^1.1.0",
@@ -14718,7 +14718,7 @@
         "potpack": "^1.0.1",
         "quickselect": "^2.0.0",
         "rw": "^1.3.3",
-        "supercluster": "^6.0.1",
+        "supercluster": "^7.0.0",
         "tinyqueue": "^2.0.0",
         "vt-pbf": "^3.1.1"
       }
@@ -17583,9 +17583,9 @@
       }
     },
     "protocol-buffers-schema": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz",
-      "integrity": "sha512-Xdayp8sB/mU+sUV4G7ws8xtYMGdQnxbeIfLjyO9TZZRJdztBGhlmbI5x1qcY4TG5hBkIKGnc28i7nXxaugu88w=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.4.0.tgz",
+      "integrity": "sha512-G/2kcamPF2S49W5yaMGdIpkG6+5wZF0fzBteLKgEHjbNzqjZQ85aAs1iJGto31EJaSTkNvHs5IXuHSaTLWBAiA=="
     },
     "proxy-addr": {
       "version": "2.0.4",
@@ -22119,9 +22119,9 @@
       }
     },
     "supercluster": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-6.0.2.tgz",
-      "integrity": "sha512-aa0v2HURjBTOpbcknilcfxGDuArM8khklKSmZ/T8ZXL0BuRwb5aRw95lz+2bmWpFvCXDX/+FzqHxmg0TIaJErw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.0.0.tgz",
+      "integrity": "sha512-8VuHI8ynylYQj7Qf6PBMWy1PdgsnBiIxujOgc9Z83QvJ8ualIYWNx2iMKyKeC4DZI5ntD9tz/CIwwZvIelixsA==",
       "requires": {
         "kdbush": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "jspdf": "^1.5.3",
     "lodash.debounce": "^4.0.8",
     "lodash.template": "~4.5.0",
-    "mapbox-gl": "~1.5.0",
+    "mapbox-gl": "^1.7.0",
     "mapbox-gl-inspect": "~1.3.1",
     "marked": "~0.7.0",
     "moize": "^5.4.4",

--- a/src/modules/Map/Map/Map.js
+++ b/src/modules/Map/Map/Map.js
@@ -47,9 +47,6 @@ export const DEFAULT_CONTROLS = [{
 }];
 
 const defaultTranslate = translateMock({
-  'terralego.map.zoom_in_control.title': 'Zoom in',
-  'terralego.map.zoom_out_control.title': 'Zoom out',
-  'terralego.map.compass_arrow_control.title': 'Reset bearing to north',
   'terralego.map.draw_control.point': 'Marker',
   'terralego.map.draw_control.polygon': 'Polygon',
   'terralego.map.draw_control.line': 'LineString',
@@ -257,17 +254,16 @@ export class MapComponent extends React.Component {
     }
   };
 
-  async initMapProperties () {
+  initMapProperties () {
     const {
       accessToken,
-      controls,
     } = this.props;
 
     mapBoxGl.accessToken = accessToken;
 
     this.createLayers();
 
-    this.resetControls(controls);
+    this.resetControls();
 
     this.toggleRotate();
   }
@@ -416,7 +412,7 @@ export class MapComponent extends React.Component {
           this.controls.push(controlInstance);
           map.addControl(controlInstance, position);
 
-          const { _container: container } = map;
+          const container = map.getContainer();
           const drawControlLocales = {
             point: translate('terralego.map.draw_control.point'),
             polygon: translate('terralego.map.draw_control.polygon'),
@@ -492,12 +488,6 @@ export class MapComponent extends React.Component {
           map.addControl(controlInstance, position);
 
           const { _container: container } = controlInstance;
-
-          if (control === CONTROL_NAVIGATION) {
-            container.querySelector('.mapboxgl-ctrl-zoom-in').setAttribute('title', translate('terralego.map.zoom_in_control.title'));
-            container.querySelector('.mapboxgl-ctrl-zoom-out').setAttribute('title', translate('terralego.map.zoom_out_control.title'));
-            container.querySelector('.mapboxgl-ctrl-compass-arrow').setAttribute('title', translate('terralego.map.compass_arrow_control.title'));
-          }
 
           if (disabled && container) {
             container.classList.add('mapboxgl-ctrl--disabled');

--- a/src/modules/Map/Map/Map.test.js
+++ b/src/modules/Map/Map/Map.test.js
@@ -45,6 +45,11 @@ jest.mock('mapbox-gl', () => {
       return off;
     }),
     fire: jest.fn(),
+    getContainer: () => ({
+      classList: {
+        add: jest.fn(),
+      },
+    }),
     getStyle: jest.fn(() => ({ layers: [{ id: 'foo' }, { id: 'bar' }] })),
     touchZoomRotate: {
       enableRotation: jest.fn(),
@@ -62,9 +67,6 @@ jest.mock('mapbox-gl', () => {
 
   const mockedControl = {
     _container: {
-      querySelector: jest.fn(() => ({
-        setAttribute: jest.fn(),
-      })),
       classList: {
         add: jest.fn(),
       },
@@ -453,11 +455,14 @@ describe('controls', () => {
     setCenter: jest.fn(),
     fitBounds: jest.fn(),
     fire: jest.fn((event, item) => item),
-    _container: {
+    getContainer: () => ({
       querySelector: jest.fn(() => ({
         setAttribute: jest.fn(),
       })),
-    },
+      classList: {
+        add: jest.fn(),
+      },
+    }),
   };
 
   beforeEach(() => {

--- a/src/modules/Map/Map/withMap.js
+++ b/src/modules/Map/Map/withMap.js
@@ -33,6 +33,7 @@ export const withMap = WrappedComponent => {
       onMapInit: PropTypes.func,
       onMapLoaded: PropTypes.func,
       onMapUpdate: PropTypes.func,
+      locale: PropTypes.shape({}),
     };
 
     static defaultProps = {
@@ -41,6 +42,7 @@ export const withMap = WrappedComponent => {
       onMapInit () {},
       onMapLoaded () {},
       onMapUpdate () {},
+      locale: {},
     };
 
     state = {
@@ -75,6 +77,7 @@ export const withMap = WrappedComponent => {
         onMapInit,
         onMapLoaded,
         hash,
+        locale,
       } = this.props;
 
       mapBoxGl.accessToken = accessToken;
@@ -93,6 +96,7 @@ export const withMap = WrappedComponent => {
         // below fix Firefox bug for printing http://fuzzytolerance.info/blog/2016/07/01/Printing-Mapbox-GL-JS-maps-in-Firefox/
         preserveDrawingBuffer: navigator.userAgent.toLowerCase().indexOf('firefox') > -1,
         hash,
+        locale,
       });
 
       // This allows accessing MapboxGL instance from console (needed for e2e tests)

--- a/src/modules/Map/Map/withMap.test.js
+++ b/src/modules/Map/Map/withMap.test.js
@@ -37,6 +37,8 @@ it('should have a map', () => {
     minZoom: undefined,
     maxBounds: undefined,
     preserveDrawingBuffer: false,
+    hash: undefined,
+    locale: {},
   });
   expect(mapboxgl.map.once).toHaveBeenCalled();
   expect(Component).toHaveBeenCalled();
@@ -72,6 +74,8 @@ it('should fit bounds', () => {
     minZoom: undefined,
     maxBounds: undefined,
     preserveDrawingBuffer: false,
+    hash: undefined,
+    locale: {},
   });
   expect(mapboxgl.map.fitBounds).toHaveBeenCalledWith(
     [[1, 2], [3, 4]],


### PR DESCRIPTION
There is a minor breaking change concerning locale management.

Before it was intended to have theses locales in the `translation.json`
```json
  "terralego": {
    "map": {
      "compass_arrow_control": {
        "title": "Orienter vers le nord"
      },
      "zoom_in_control": {
        "title": "Zoomer"
      },
      "zoom_out_control": {
        "title": "Dézoomer"
      }
    }
```
Now, we need to pass a `locale` obj prop to the Map component 
```js
{
    'FullscreenControl.Enter': 'Enter fullscreen',
    'FullscreenControl.Exit': 'Exit fullscreen',
    'GeolocateControl.FindMyLocation': 'Find my location',
    'GeolocateControl.LocationNotAvailable': 'Location not available',
    'LogoControl.Title': 'Mapbox logo',
    'NavigationControl.ResetBearing': 'Reset bearing to north',
    'NavigationControl.ZoomIn': 'Zoom in',
    'NavigationControl.ZoomOut': 'Zoom out',
    'ScaleControl.Feet': 'ft',
    'ScaleControl.Meters': 'm',
    'ScaleControl.Kilometers': 'km',
    'ScaleControl.Miles': 'mi',
    'ScaleControl.NauticalMiles': 'nm'
}
```
to override default translations.

Anyways, we can put these in the translation.js
```json
  "terralego": {
     "map": {
      "NavigationControl.apResetBearing": "Orienter vers le nord",
      "NavigationControl.ZoomIn": "Zoomer",
      "NavigationControl.ZoomOut": "Dézoomer"
       // etc
    }
  },
```
And get the object with `i18n.getDataByLanguage(lng)`