### PR TITLE
Extends main menu icon props

### DIFF
--- a/src/components/HeaderButton.js
+++ b/src/components/HeaderButton.js
@@ -1,29 +1,48 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
-import { Button } from '@blueprintjs/core';
+import { Classes, Button } from '@blueprintjs/core';
 
-export const HeaderButton = ({ id, icon, alt }) => (
-  <Button
-    className={`header-button ${id}`}
-    minimal
-    id={id}
-  >
-    {icon
-      ? <img src={icon} alt={alt} />
-      : <span>{alt}</span>}
-  </Button>
-);
+const getIcon = (icon, alt) => {
+  if (!icon) {
+    return null;
+  }
+  const isPathIcon = typeof icon === 'string' && icon.includes('.');
+  return !isPathIcon
+    ? icon
+    : (
+      <span className={Classes.ICON}>
+        <img src={icon} alt={alt} />
+      </span>
+    );
+};
+
+
+export const HeaderButton = ({ alt, className, icon, ...props }) => {
+  const formattedIcon = getIcon(icon, alt);
+
+  return (
+    <Button
+      className={classnames(['header-button', className])}
+      icon={formattedIcon}
+      minimal
+      text={!formattedIcon && alt}
+      {...props}
+    />
+  );
+};
 
 HeaderButton.propTypes = {
-  id: PropTypes.string.isRequired,
-  icon: PropTypes.string,
   alt: PropTypes.string,
+  className: PropTypes.string,
+  icon: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({})]),
 };
 
 HeaderButton.defaultProps = {
-  icon: '',
   alt: '',
+  className: '',
+  icon: undefined,
 };
 
 export default HeaderButton;

--- a/src/components/HeaderButton.test.js
+++ b/src/components/HeaderButton.test.js
@@ -1,15 +1,38 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { Icon } from '@blueprintjs/core';
 import { HeaderButton } from './HeaderButton';
 
 import defaultLogo from '../images/defaultLogo.svg';
 
-it('should render correctly', () => {
+it('should render correctly with Icon path', () => {
   const tree = renderer.create(
     <HeaderButton
       id="theme"
       icon={defaultLogo}
       alt="default logo"
+    />,
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('should render correctly with Icon keyword', () => {
+  const tree = renderer.create(
+    <HeaderButton
+      id="theme"
+      icon="log-in"
+      alt="Login"
+    />,
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('should render correctly with Icon component', () => {
+  const tree = renderer.create(
+    <HeaderButton
+      id="theme"
+      icon={<Icon icon="info-sign" />}
+      alt="InfoSign"
     />,
   ).toJSON();
   expect(tree).toMatchSnapshot();

--- a/src/components/MainMenu.js
+++ b/src/components/MainMenu.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import {
+  Classes,
   Navbar,
   NavbarGroup,
 } from '@blueprintjs/core';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
 import NavBarItemDesktop from './NavBarItemDesktop';
 import NavBarItemTablet from './NavBarItemTablet';
@@ -11,45 +13,57 @@ import NavBarItemTablet from './NavBarItemTablet';
 import withDeviceSize from '../hoc/withDeviceSize';
 import { connectAuthProvider } from '../modules/Auth';
 
-
-/* eslint-disable react/no-array-index-key */
 export const MainMenu = ({
+  className,
   isMobileSized,
+  isPhoneSized,
   navItems,
-}) => (
-  <Navbar className="navBar bp3-dark">
-    {
-          navItems.map((group, index) => (
-            <NavbarGroup key={index} className="navBar__group">
-              {group.map(({ component: Component = isMobileSized
-                ? NavBarItemTablet : NavBarItemDesktop, ...item }) => (
-                  <Component
-                    key={item.label}
-                    icon={item.icon}
-                    {...item}
-                  />
-              ))}
-            </NavbarGroup>
-          ))
-        }
-  </Navbar>
-);
+  ...props
+}) => {
+  if (!navItems.length) {
+    return null;
+  }
+
+  const defaultComponent = isMobileSized ? NavBarItemTablet : NavBarItemDesktop;
+
+  return (
+    <Navbar className={classnames(['navBar', Classes.DARK, className])} {...props}>
+      {navItems.map((group, index) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <NavbarGroup key={index} className="navBar__group">
+          {group.map(({ component: Component = defaultComponent, ...item }) => (
+            <Component
+              key={item.id}
+              {...item}
+            />
+          ))}
+        </NavbarGroup>
+      ))}
+    </Navbar>
+  );
+};
 
 MainMenu.propTypes = {
+  className: PropTypes.string,
   isMobileSized: PropTypes.bool,
+  isPhoneSized: PropTypes.bool,
   navItems: PropTypes.arrayOf(
     PropTypes.arrayOf(
       PropTypes.shape({
+        component: PropTypes.func,
+        href: PropTypes.string,
+        icon: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({})]),
         id: PropTypes.string,
         label: PropTypes.string,
-        icon: PropTypes.string,
       }),
     ),
   ),
 };
 
 MainMenu.defaultProps = {
+  className: '',
   isMobileSized: false,
+  isPhoneSized: false,
   navItems: [],
 };
 

--- a/src/components/MainMenu.test.js
+++ b/src/components/MainMenu.test.js
@@ -15,7 +15,7 @@ it('should render properly', () => {
       navItems={[[
         { label: 'log in', icon: login },
         { label: 'log out', icon: logout },
-        { label: 'info sign', icon: infosign, id: 'ingosign' },
+        { label: 'info sign', icon: infosign },
       ]]}
     />,
   ).toJSON();

--- a/src/components/NavBarItemDesktop.js
+++ b/src/components/NavBarItemDesktop.js
@@ -39,15 +39,17 @@ export const NavBarItemDesktop = ({
 );
 
 NavBarItemDesktop.propTypes = {
-  id: PropTypes.string.isRequired,
-  href: PropTypes.string.isRequired,
-  icon: PropTypes.string,
+  id: PropTypes.string,
+  href: PropTypes.string,
+  icon: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({})]),
   label: PropTypes.string,
   content: PropTypes.string,
   onClick: PropTypes.func,
 };
 
 NavBarItemDesktop.defaultProps = {
+  id: null,
+  href: '',
   icon: '',
   label: '',
   content: '',

--- a/src/components/NavBarItemTablet.js
+++ b/src/components/NavBarItemTablet.js
@@ -26,14 +26,16 @@ export const NavBarItemTablet = ({
 );
 
 NavBarItemTablet.propTypes = {
-  id: PropTypes.string.isRequired,
-  href: PropTypes.string.isRequired,
+  id: PropTypes.string,
+  href: PropTypes.string,
   icon: PropTypes.string,
   label: PropTypes.string,
   onClick: PropTypes.func,
 };
 
 NavBarItemTablet.defaultProps = {
+  id: null,
+  href: '',
   icon: '',
   label: '',
   onClick () {},

--- a/src/components/__snapshots__/HeaderButton.test.js.snap
+++ b/src/components/__snapshots__/HeaderButton.test.js.snap
@@ -1,15 +1,75 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should render correctly 1`] = `
+exports[`should render correctly with Icon component 1`] = `
 <button
-  className="bp3-button bp3-minimal header-button theme"
+  className="bp3-button bp3-minimal header-button"
   id="theme"
   onKeyDown={[Function]}
   onKeyUp={[Function]}
   type="button"
 >
   <span
-    className="bp3-button-text"
+    className="bp3-icon bp3-icon-info-sign"
+    icon="info-sign"
+  >
+    <svg
+      data-icon="info-sign"
+      height={16}
+      viewBox="0 0 16 16"
+      width={16}
+    >
+      <desc>
+        info-sign
+      </desc>
+      <path
+        d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zM7 3h2v2H7V3zm3 10H6v-1h1V7H6V6h3v6h1v1z"
+        fillRule="evenodd"
+      />
+    </svg>
+  </span>
+</button>
+`;
+
+exports[`should render correctly with Icon keyword 1`] = `
+<button
+  className="bp3-button bp3-minimal header-button"
+  id="theme"
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  type="button"
+>
+  <span
+    className="bp3-icon bp3-icon-log-in"
+    icon="log-in"
+  >
+    <svg
+      data-icon="log-in"
+      height={16}
+      viewBox="0 0 16 16"
+      width={16}
+    >
+      <desc>
+        log-in
+      </desc>
+      <path
+        d="M11 8c0-.28-.11-.53-.29-.71l-3-3a1.003 1.003 0 00-1.42 1.42L7.59 7H1c-.55 0-1 .45-1 1s.45 1 1 1h6.59L6.3 10.29c-.19.18-.3.43-.3.71a1.003 1.003 0 001.71.71l3-3c.18-.18.29-.43.29-.71zm4-8H9c-.55 0-1 .45-1 1s.45 1 1 1h5v12H9c-.55 0-1 .45-1 1s.45 1 1 1h6c.55 0 1-.45 1-1V1c0-.55-.45-1-1-1z"
+        fillRule="evenodd"
+      />
+    </svg>
+  </span>
+</button>
+`;
+
+exports[`should render correctly with Icon path 1`] = `
+<button
+  className="bp3-button bp3-minimal header-button"
+  id="theme"
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  type="button"
+>
+  <span
+    className="bp3-icon"
   >
     <img
       alt="default logo"
@@ -21,7 +81,7 @@ exports[`should render correctly 1`] = `
 
 exports[`should render correctly without icon 1`] = `
 <button
-  className="bp3-button bp3-minimal header-button theme"
+  className="bp3-button bp3-minimal header-button"
   id="theme"
   onKeyDown={[Function]}
   onKeyUp={[Function]}
@@ -30,9 +90,7 @@ exports[`should render correctly without icon 1`] = `
   <span
     className="bp3-button-text"
   >
-    <span>
-      default logo
-    </span>
+    default logo
   </span>
 </button>
 `;

--- a/src/stories/modules/Menu/MainMenu.stories.js
+++ b/src/stories/modules/Menu/MainMenu.stories.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { Icon } from '@blueprintjs/core';
 
 import MainMenu from '../../../components/MainMenu';
 
 import login from '../../../images/log-in.svg';
-import logout from '../../../images/log-out.svg';
-import infosign from '../../../images/info-sign.svg';
+
+// eslint-disable-next-line no-alert
+const handleClick = () => alert('it works');
 
 const stories = storiesOf('Components/Menu', module);
 stories
@@ -13,18 +15,19 @@ stories
     <MainMenu
       navItems={[[
         { label: 'log in', icon: login, id: 'login' },
-        { label: 'log out', icon: logout, id: 'logout' },
-        { label: 'info sign', icon: infosign, id: 'ingosign' },
+        { label: 'log out', icon: 'log-out', id: 'logout' },
+        { label: 'info sign', icon: <Icon icon="info-sign" />, id: 'infosign' },
+        { label: 'Close', id: 'close' },
       ]]}
     />
   ))
   .add('MainMenu | custom', () => (
     <MainMenu
       navItems={[[
-        { component: () => <button type="button">click me</button> },
-        { component: () => <img style={{ marginLeft: '10px' }} src={login} alt="login logo" /> },
-        { component: () => <div style={{ marginLeft: '10px' }}>check me<input type="checkbox" /></div> },
-        { component: () => <div style={{ marginLeft: '10px' }}>search me<input type="text" /></div> },
+        { component: () => <button type="button" onClick={handleClick}>click me</button>, id: 'customComponent1' },
+        { component: () => <img style={{ marginLeft: '10px' }} src={login} alt="login logo" />, id: 'customComponent2' },
+        { component: () => <div style={{ marginLeft: '10px' }}>check me<input type="checkbox" /></div>, id: 'customComponent3' },
+        { component: () => <div style={{ marginLeft: '10px' }}>search me<input type="text" /></div>, id: 'customComponent4' },
       ]]}
     />
   ));

--- a/src/stories/modules/NavBarItem/NavbarItemDesktop.stories.js
+++ b/src/stories/modules/NavBarItem/NavbarItemDesktop.stories.js
@@ -11,7 +11,7 @@ stories
   .addDecorator(story => <MemoryRouter>{story()}</MemoryRouter>)
   .add('NavBarItemDesktop', () => (
     <NavBarItemDesktop
-      id={42}
+      id="42"
       label="item label"
       href="#"
       onClick={() => {}}

--- a/src/stories/modules/NavBarItem/NavbarItemTablet.stories.js
+++ b/src/stories/modules/NavBarItem/NavbarItemTablet.stories.js
@@ -6,13 +6,12 @@ import NavBarItemTablet from '../../../components/NavBarItemTablet';
 
 import logo from '../../../images/defaultLogo.svg';
 
-
 const stories = storiesOf('Components/NavBarItem', module);
 stories
   .addDecorator(story => <MemoryRouter>{story()}</MemoryRouter>)
   .add('NavBarItemTablet', () => (
     <NavBarItemTablet
-      id={42}
+      id="42"
       label="item label"
       href="#"
       onClick={() => {}}


### PR DESCRIPTION
We can now set `icon` for `HeaderButton` in three differents ways:
```jsx
// By image path
import login from '../images/login.svg';

<HeaderButton
  icon={login}
  alt="Login"
/>
```

```jsx
// By KeyWord accepted by bluePrint
<HeaderButton
  icon="login"
  alt="Login"
/>
```

```jsx
// By Component acting like an Icon
import { Icon } from 'whateverLib';

<HeaderButton
  icon={<Icon icon="login" />}
  alt="Login"
/>
```