### PR TITLE
Add link prop to main menu to manage routing pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14705,20 +14705,6 @@
       "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
       "dev": true
     },
-    "history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -19016,17 +19002,6 @@
         "dom-walk": "^0.1.0"
       }
     },
-    "mini-create-react-context": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
-      "integrity": "sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.4.0",
-        "gud": "^1.0.0",
-        "tiny-warning": "^1.0.2"
-      }
-    },
     "mini-css-extract-plugin": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.7.0.tgz",
@@ -22454,56 +22429,6 @@
         "resize-observer-polyfill": "^1.5.1"
       }
     },
-    "react-router": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz",
-      "integrity": "sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.3.0",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "path-to-regexp": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-          "dev": true,
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        }
-      }
-    },
-    "react-router-dom": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.1.2.tgz",
-      "integrity": "sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.1.2",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      }
-    },
     "react-scripts": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-2.1.8.tgz",
@@ -25077,12 +25002,6 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
-    "resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
-      "dev": true
-    },
     "resolve-protobuf-schema": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
@@ -27522,18 +27441,6 @@
       "dev": true,
       "optional": true
     },
-    "tiny-invariant": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
-      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==",
-      "dev": true
-    },
-    "tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-      "dev": true
-    },
     "tinycolor2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
@@ -28212,12 +28119,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
-      "dev": true
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "npm-run-all": "~4.1.5",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "react-router-dom": "^5.1.2",
     "react-scripts": "^2.1.8",
     "react-test-renderer": "^16.8.6",
     "replace": "~1.1.0",

--- a/src/components/HeaderLink.js
+++ b/src/components/HeaderLink.js
@@ -1,34 +1,46 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { NavLink } from 'react-router-dom';
 import classnames from 'classnames';
 
-export const HeaderLink = ({ children, className, exact, href, ...props }) => {
-  const classes = classnames(['header-link', className]);
+export const HeaderLink = ({ className, href, link, ...props }) => {
+  const {
+    component: Component,
+    linkProps: { hrefAttribute, ...linkProps },
+  } = link || {
+    component: href ? 'a' : 'span',
+    linkProps: { hrefAttribute: 'href' },
+  };
 
-  if (!href) {
-    return <span className={classes} {...props}>{children}</span>;
-  }
-
-  if (href.startsWith('http')) {
-    return <a className={classes} href={href} {...props}>{children}</a>;
-  }
+  const hrefProp = href && {
+    [hrefAttribute]: href,
+  };
 
   return (
-    <NavLink className={classes} to={href} exact={exact} {...props}>{children}</NavLink>
+    <Component
+      className={classnames(['header-link', className])}
+      {...hrefProp}
+      {...linkProps}
+      {...props}
+    />
   );
 };
 
 HeaderLink.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.element.isRequired,
   className: PropTypes.string,
-  exact: PropTypes.bool,
   href: PropTypes.string,
+  link: PropTypes.shape({
+    component: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+    linkProps: PropTypes.shape({
+      hrefAttribute: PropTypes.string,
+    }),
+  }),
 };
 
 HeaderLink.defaultProps = {
   className: '',
-  exact: false,
   href: '',
+  link: undefined,
 };
+
 export default HeaderLink;

--- a/src/components/HeaderLink.test.js
+++ b/src/components/HeaderLink.test.js
@@ -2,9 +2,6 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { HeaderLink } from './HeaderLink';
 
-jest.mock('react-router-dom', () => ({
-  NavLink: ({ children, ...props }) => <a {...props}>{children}</a>,
-}));
 
 it('should render correctly with no href', () => {
   const tree = renderer.create(
@@ -27,7 +24,7 @@ it('should render correctly with http link', () => {
 
 it('should render correctly with navigation', () => {
   const tree = renderer.create(
-    <HeaderLink href="foo">
+    <HeaderLink href="foo" link={{ component: 'button', linkProps: { hrefAttribute: 'to' } }}>
       <span>Bar</span>
     </HeaderLink>,
   ).toJSON();

--- a/src/components/NavBarItemDesktop.js
+++ b/src/components/NavBarItemDesktop.js
@@ -13,8 +13,6 @@ export const NavBarItemDesktop = ({
   id,
   content,
   label,
-  href,
-  onClick,
   icon,
   ...props
 }) => (
@@ -24,10 +22,7 @@ export const NavBarItemDesktop = ({
     usePortal={false}
   >
     <HeaderLink
-      href={href}
-      onClick={onClick}
       data-link-id={id}
-      exact
       {...props}
     >
       <HeaderButton

--- a/src/components/NavBarItemTablet.js
+++ b/src/components/NavBarItemTablet.js
@@ -7,16 +7,11 @@ import HeaderButton from './HeaderButton';
 export const NavBarItemTablet = ({
   id,
   label,
-  href,
-  onClick,
   icon,
   ...props
 }) => (
   <HeaderLink
-    href={href}
-    onClick={onClick}
     data-link-id={id}
-    exact
     {...props}
   >
     <p className="header-button-label">{label}</p>

--- a/src/components/__snapshots__/HeaderLink.test.js.snap
+++ b/src/components/__snapshots__/HeaderLink.test.js.snap
@@ -12,15 +12,14 @@ exports[`should render correctly with http link 1`] = `
 `;
 
 exports[`should render correctly with navigation 1`] = `
-<a
+<button
   className="header-link"
-  exact={false}
   to="foo"
 >
   <span>
     Bar
   </span>
-</a>
+</button>
 `;
 
 exports[`should render correctly with no href 1`] = `

--- a/src/stories/modules/Header/HeaderLink.stories.js
+++ b/src/stories/modules/Header/HeaderLink.stories.js
@@ -1,12 +1,10 @@
 import React from 'react';
-import { MemoryRouter } from 'react-router';
 import { storiesOf } from '@storybook/react';
 
 import HeaderLink from '../../../components/HeaderLink';
 
 const stories = storiesOf('Components/Header', module);
 stories
-  .addDecorator(story => <MemoryRouter>{story()}</MemoryRouter>)
   .add('HeaderLink', () => (
     <HeaderLink href="#">HeaderLink component</HeaderLink>
   ));

--- a/src/stories/modules/Menu/MainMenu.stories.js
+++ b/src/stories/modules/Menu/MainMenu.stories.js
@@ -9,15 +9,30 @@ import './styles.scss';
 
 // eslint-disable-next-line no-alert
 const handleClick = () => alert('it works');
+const Link = props => <div title="MOCK CUSTOM LINK" {...props} />;
 
 const stories = storiesOf('Components/Menu', module);
 stories
   .add('MainMenu | default', () => (
     <MainMenu
       navItems={[[
-        { label: 'log in', icon: login, id: 'login' },
+        {
+          label: 'log in',
+          icon: login,
+          id: 'login',
+          href: 'path/to/login',
+        },
         { label: 'log out', icon: 'log-out', id: 'logout' },
-        { label: 'info sign', icon: <Icon icon="info-sign" />, id: 'infosign' },
+        {
+          label: 'info sign',
+          icon: <Icon icon="info-sign" />,
+          id: 'infosign',
+          href: 'path/test',
+          link: {
+            component: Link,
+            linkProps: { hrefAttribute: 'to' },
+          },
+        },
         { label: 'Close', id: 'close' },
       ]]}
     />

--- a/src/stories/modules/NavBarItem/NavbarItemDesktop.stories.js
+++ b/src/stories/modules/NavBarItem/NavbarItemDesktop.stories.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
 import { storiesOf } from '@storybook/react';
 
 import NavBarItemDesktop from '../../../components/NavBarItemDesktop';
@@ -8,7 +7,6 @@ import logo from '../../../images/defaultLogo.svg';
 
 const stories = storiesOf('Components/NavBarItem', module);
 stories
-  .addDecorator(story => <MemoryRouter>{story()}</MemoryRouter>)
   .add('NavBarItemDesktop', () => (
     <NavBarItemDesktop
       id="42"

--- a/src/stories/modules/NavBarItem/NavbarItemTablet.stories.js
+++ b/src/stories/modules/NavBarItem/NavbarItemTablet.stories.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
 import { storiesOf } from '@storybook/react';
 
 import NavBarItemTablet from '../../../components/NavBarItemTablet';
@@ -8,7 +7,6 @@ import logo from '../../../images/defaultLogo.svg';
 
 const stories = storiesOf('Components/NavBarItem', module);
 stories
-  .addDecorator(story => <MemoryRouter>{story()}</MemoryRouter>)
   .add('NavBarItemTablet', () => (
     <NavBarItemTablet
       id="42"


### PR DESCRIPTION
In order to make MainMenu component agnostic, we need to remove the `react-router-dom` dependencies from the project.
With this PR, the NavLink component (or whatever other link component) must be forwarded directly from the project using it to the MainMenu component.