### PR TITLE
Force fitbounds on specific bbox for each view

### DIFF
--- a/src/components/NavBarItemDesktop.js
+++ b/src/components/NavBarItemDesktop.js
@@ -8,12 +8,14 @@ import {
 
 import HeaderLink from './HeaderLink';
 import HeaderButton from './HeaderButton';
+import { connectState } from '../modules/State/context';
 
 export const NavBarItemDesktop = ({
   id,
   content,
   label,
   icon,
+  setForceFitBounds,
   ...props
 }) => (
   <Tooltip
@@ -29,6 +31,7 @@ export const NavBarItemDesktop = ({
         id={id}
         icon={icon}
         alt={label}
+        onClick={() => setForceFitBounds(true)}
       >
         {content}
       </HeaderButton>
@@ -54,4 +57,4 @@ NavBarItemDesktop.defaultProps = {
   onClick () {},
 };
 
-export default NavBarItemDesktop;
+export default connectState('setForceFitBounds')(NavBarItemDesktop);

--- a/src/modules/Map/InteractiveMap/InteractiveMap.js
+++ b/src/modules/Map/InteractiveMap/InteractiveMap.js
@@ -717,4 +717,4 @@ export class InteractiveMap extends React.Component {
   }
 }
 
-export default connectState('initialState')(InteractiveMap);
+export default connectState('initialState', 'forceFitBounds')(InteractiveMap);

--- a/src/modules/Map/Map/withMap.js
+++ b/src/modules/Map/Map/withMap.js
@@ -215,8 +215,8 @@ export const withMap = WrappedComponent => {
         hash,
         locale,
         layerTypesWeight,
+        forceFitBounds,
       } = this.props;
-
       mapBoxGl.accessToken = accessToken;
 
       const hasHash = hash && !!global.location.hash;
@@ -243,7 +243,7 @@ export const withMap = WrappedComponent => {
         this.containerEl.current.mapboxInstance = map;
       }
 
-      if (!hasHash && fitBounds) {
+      if (fitBounds && (forceFitBounds || !hasHash)) {
         const { coordinates, ...fitBoundsParams } = fitBounds;
         map.fitBounds(coordinates, fitBoundsParams);
       }

--- a/src/modules/State/Hash/withHashState.js
+++ b/src/modules/State/Hash/withHashState.js
@@ -44,14 +44,19 @@ export const withHashState = WrappedComponent => {
 
     componentDidMount () {
       const { listenHash } = this.props;
+      const { initialState } = this.state;
+
       if (listenHash) {
         window.addEventListener('hashchange', this.onHashChange, false);
       }
+
+      this.setState({ forceFitBounds: !Object.keys(initialState).length });
     }
 
     componentWillUnmount () {
       this.isUnmount = true;
       window.removeEventListener('hashchange', this.onHashChange, false);
+      document.addEventListener('DOMContentLoaded', this.forceFitBounds);
     }
 
     /**
@@ -76,12 +81,16 @@ export const withHashState = WrappedComponent => {
       }
     };
 
+    setForceFitBounds = forceFitBounds => this.setState({ forceFitBounds });
+
     render () {
       const { listenHash, updateHash, ...props } = this.props;
-      const { initialState } = this.state;
+      const { initialState, forceFitBounds } = this.state;
       return (
         <WrappedComponent
           initialState={initialState}
+          forceFitBounds={forceFitBounds}
+          setForceFitBounds={this.setForceFitBounds}
           {...props}
           getCurrentHashString={getCurrentHashString}
           onStateChange={this.updateHashString}

--- a/src/modules/State/StateProvider.js
+++ b/src/modules/State/StateProvider.js
@@ -22,11 +22,13 @@ export class StateProvider extends React.Component {
   };
 
   render () {
-    const { children } = this.props;
+    const { children, forceFitBounds, setForceFitBounds } = this.props;
     return (
       <Provider value={{
         initialState: this.state,
         setCurrentState: this.setCurrentState,
+        forceFitBounds,
+        setForceFitBounds,
       }}
       >
         {children}


### PR DESCRIPTION
When accessing a view with a specific bbox set in settings, force a
fitbound of the map. It must not be force when accessing view from an
url with hash parameter set