### PR TITLE
Remove map on draw.render event

### DIFF
--- a/src/modules/Map/Map/Map.js
+++ b/src/modules/Map/Map/Map.js
@@ -543,7 +543,8 @@ export class MapComponent extends React.Component {
 
           map.addControl(controlInstance, position);
           map.on('draw.modechange', () => controlInstance.renderContainer(this.draw, translate));
-          map.on('draw.render', () => controlInstance.renderContainer(this.draw, translate));
+          map.once('draw.render', () => controlInstance.renderContainer(this.draw, translate));
+          map.on('draw.update', () => controlInstance.renderContainer(this.draw, translate));
           break;
         }
         default: {


### PR DESCRIPTION
@CFarcy There's on issue with the measure_control firing LOTS of error in the console and re-rendering on each mouse move.

I tried this and it works, do you think I missed something?